### PR TITLE
Added an optional upper limit to the numbers of items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,11 @@
     ],
     "require":
     {
-        "php":                  "^5.5|^7.0",
-        "psr/cache":            "~1.0",
-        "cache/adapter-common": "^0.2",
-        "cache/taggable-cache": "^0.3"
+        "php":                      "^5.5|^7.0",
+        "psr/cache":                "~1.0",
+        "cache/adapter-common":     "^0.2",
+        "cache/hierarchical-cache": "^0.2",
+        "cache/taggable-cache":     "^0.3"
     },
     "require-dev":
     {

--- a/composer.json
+++ b/composer.json
@@ -28,18 +28,18 @@
     "require":
     {
         "php":                  "^5.5|^7.0",
-        "psr/cache":            "1.0.0",
-        "cache/adapter-common": "^0.1",
+        "psr/cache":            "~1.0",
+        "cache/adapter-common": "^0.2",
         "cache/taggable-cache": "^0.3"
     },
     "require-dev":
     {
         "phpunit/phpunit":         "^5.1|^4.0",
-        "cache/integration-tests": "^0.4"
+        "cache/integration-tests": "^0.7"
     },
     "provide":
     {
-        "psr/cache-implementation": "1.0.0"
+        "psr/cache-implementation": "~1.0"
     },
     "autoload":
     {

--- a/src/ArrayCachePool.php
+++ b/src/ArrayCachePool.php
@@ -12,6 +12,7 @@
 namespace Cache\Adapter\PHPArray;
 
 use Cache\Adapter\Common\AbstractCachePool;
+use Cache\Adapter\Common\CacheItem;
 use Psr\Cache\CacheItemInterface;
 
 /**
@@ -32,15 +33,35 @@ class ArrayCachePool extends AbstractCachePool
         $this->cache = &$cache;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function getItemWithoutGenerateCacheKey($key)
+    {
+        if (isset($this->deferred[$key])) {
+            $item = $this->deferred[$key];
+
+            return is_object($item) ? clone $item : $item;
+        }
+
+        return $this->fetchObjectFromCache($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function fetchObjectFromCache($key)
     {
         if (isset($this->cache[$key])) {
             return $this->cache[$key];
         }
 
-        return false;
+        return new CacheItem($key, false);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function clearAllObjectsFromCache()
     {
         $this->cache = [];
@@ -48,6 +69,9 @@ class ArrayCachePool extends AbstractCachePool
         return true;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function clearOneObjectFromCache($key)
     {
         unset($this->cache[$key]);
@@ -55,6 +79,9 @@ class ArrayCachePool extends AbstractCachePool
         return true;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function storeItemInCache($key, CacheItemInterface $item, $ttl)
     {
         $this->cache[$key] = $item;

--- a/tests/ArrayCachePoolTest.php
+++ b/tests/ArrayCachePoolTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of php-cache\array-adapter package.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Adapter\PHPArray\Tests;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+
+class ArrayCachePoolTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLimit()
+    {
+        $pool = new ArrayCachePool(2);
+        $item = $pool->getItem('key1')->set('value1');
+        $pool->save($item);
+
+        $item = $pool->getItem('key2')->set('value2');
+        $pool->save($item);
+
+        // Both items should be in the pool, nothing strange yet
+        $this->assertTrue($pool->hasItem('key1'));
+        $this->assertTrue($pool->hasItem('key2'));
+
+        $item = $pool->getItem('key3')->set('value3');
+        $pool->save($item);
+
+        // First item should be dropped
+        $this->assertFalse($pool->hasItem('key1'));
+        $this->assertTrue($pool->hasItem('key2'));
+        $this->assertTrue($pool->hasItem('key3'));
+
+        $this->assertFalse($pool->getItem('key1')->isHit());
+        $this->assertTrue($pool->getItem('key2')->isHit());
+        $this->assertTrue($pool->getItem('key3')->isHit());
+
+        $item = $pool->getItem('key4')->set('value4');
+        $pool->save($item);
+
+        // Only the last two items should be in place
+        $this->assertFalse($pool->hasItem('key1'));
+        $this->assertFalse($pool->hasItem('key2'));
+        $this->assertTrue($pool->hasItem('key3'));
+        $this->assertTrue($pool->hasItem('key4'));
+    }
+}

--- a/tests/CreatePoolTrait.php
+++ b/tests/CreatePoolTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Cache\Adapter\PHPArray\Tests;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+
+trait CreatePoolTrait
+{
+    private $cacheArray = [];
+
+    public function createCachePool()
+    {
+        return new ArrayCachePool($this->cacheArray);
+    }
+}

--- a/tests/CreatePoolTrait.php
+++ b/tests/CreatePoolTrait.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of php-cache\array-adapter package.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Cache\Adapter\PHPArray\Tests;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
@@ -10,6 +19,6 @@ trait CreatePoolTrait
 
     public function createCachePool()
     {
-        return new ArrayCachePool($this->cacheArray);
+        return new ArrayCachePool(null, $this->cacheArray);
     }
 }

--- a/tests/IntegrationHierarchicalTest.php
+++ b/tests/IntegrationHierarchicalTest.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of php-cache\array-adapter package.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Adapter\PHPArray\Tests;
+
+use Cache\IntegrationTests\HierarchicalCachePoolTest;
+
+class IntegrationHierarchicalTest extends HierarchicalCachePoolTest
+{
+    use CreatePoolTrait;
+}

--- a/tests/IntegrationPoolTest.php
+++ b/tests/IntegrationPoolTest.php
@@ -11,15 +11,9 @@
 
 namespace Cache\Adapter\PHPArray\Tests;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Cache\IntegrationTests\CachePoolTest;
 
 class IntegrationPoolTest extends CachePoolTest
 {
-    private $cacheArray = [];
-
-    public function createCachePool()
-    {
-        return new ArrayCachePool($this->cacheArray);
-    }
+    use CreatePoolTrait;
 }

--- a/tests/IntegrationTagTest.php
+++ b/tests/IntegrationTagTest.php
@@ -11,15 +11,9 @@
 
 namespace Cache\Adapter\PHPArray\Tests;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Cache\IntegrationTests\TaggableCachePoolTest;
 
 class IntegrationTagTest extends TaggableCachePoolTest
 {
-    private $cacheArray = [];
-
-    public function createCachePool()
-    {
-        return new ArrayCachePool($this->cacheArray);
-    }
+    use CreatePoolTrait;
 }


### PR DESCRIPTION
I've updated to the adapter common 0.2. I added support for hierarchy. I did also fix https://github.com/php-cache/issues/issues/20 by adding an optional upper limit for the numbers of items in the cache. 

Ping @andrerom does https://github.com/php-cache/array-adapter/commit/51ec6fcca417a3216ff9f399769da5e8f0cae68f fix your issue?
